### PR TITLE
Added ListItem update function, implemented $filter, $select, $expand, FieldValuesAsText

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ var listItemData {
     'type': 'SP.Data.MyListItem'}, //type is the item's type AKA ListItemEntityTypeFullName of the List to which the item belongs
   'Title': 'Jim Wuz Here' //Item Field to update : Data to update the Field with
 }
-sharepoint.listItems.update(req.params.guid, listItemData, function(res));
+sharepoint.listItems.update('someListGUID', listItemData, function(res));
 ```
 
 ###ListItem Delete

--- a/README.md
+++ b/README.md
@@ -192,6 +192,18 @@ sharepoint.lists.read('someListGUID', function(err, listReadResult){
 });
 ```
 
+##ListItem Update
+To update a ListItem, we use the update() function.
+```javascript
+var listItemData {
+  itemId: ListItemID, //Value of the item's ID field
+  '__metadata': {
+    'type': 'SP.Data.MyListItem'}, //type is the item's type AKA ListItemEntityTypeFullName of the List to which the item belongs
+  'Title': 'Jim Wuz Here' //Item Field to update : Data to update the Field with
+}
+sharepoint.listItems.update(req.params.guid, listItemData, function(res));
+```
+
 ###ListItem Delete
 To delete a ListItem, we can use the del() function.
 ```javascript

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ sharepoint.login(function(err){
   });
 });
 ```
-    
+
 ##Paramaters
 When initialising Sharepoint, there are a number of optional params which can be specified at init. Here are their defaults & descriptions
 ```javascript
@@ -39,25 +39,29 @@ var sharepoint = require('sharepoint')({
   context : 'myCustomerSite', // Set to create resources outside of the base site context, `web`
   verbose : false, // Set to true to stop filtering responses, instead returning everything
   proxy : undefined, // set to string hostname of proxy if running through one
-  strictSSL : true // set to false if connecting to SP instance with self-signed cert
+  strictSSL : true, // set to false if connecting to SP instance with self-signed cert
+  fieldValuesAsText : true, //Return Lookup Field Values as Text for Items
+  filterFields : ["{\"field\": \"field1\", \"value\": \"value1\"}"], //Filter Items in List based on field value(s) $filter=
+  selectFields : ['field1', 'field2'], //Only return List or Item data for fields specified $select=
+  expandFields : ['field1', 'field2'] //"JOIN" another list based on a lookup value and return data $expand=
 });
 ```
-    
+
 # A Sharepoint Primer
 Skip this if you already know enough about SharePoint.  
 Here's the basics I wanted to know about this product before I began integrating:
 
 
 * Sharepoint is a number of products:
-  * SharePoint 2013 - the on premise version of Sharepoint which I've seen most often. 
-  * Sharepoint 365 - the online SharePoint product. 
-* **Everything is a List** in SharePoint. Document Library? A list. The tasks app? Just a list. Discussion Board? You got it, it's a list. Site Pages? List. Turns out, Sharepoint reuses the base type `List` for a lot of things. 
-    
-    
+  * SharePoint 2013 - the on premise version of Sharepoint which I've seen most often.
+  * Sharepoint 365 - the online SharePoint product.
+* **Everything is a List** in SharePoint. Document Library? A list. The tasks app? Just a list. Discussion Board? You got it, it's a list. Site Pages? List. Turns out, Sharepoint reuses the base type `List` for a lot of things.
+
+
 # Methods
 
 ## Lists
-As mentioned above, SharePoint is driven by lists. The base SharePoint API allows you to `CRUDL` lists, but the read operation doesn't return Items[] or Fields[] - this is a separate API operation. 
+As mentioned above, SharePoint is driven by lists. The base SharePoint API allows you to `CRUDL` lists, but the read operation doesn't return Items[] or Fields[] - this is a separate API operation.
 With Sharepointer, list read operations also retrieve all Fields[] and Items[] on the list for convenience.  
 
 ### Lists List
@@ -67,19 +71,19 @@ sharepoint.lists.list(function(err, listRes){
   // listRes will be an array of lists [{ Id : '1a2b3c', ... }, { Id : '2b3c4d' }, { Id : '5d6e7f' }]
 });
 ```
-You can now use any of the following functions to operate upon lists. Note that each `lists` object in the array will also have a convenience function which operates on itself for read, update & delete. These are also documented below. 
+You can now use any of the following functions to operate upon lists. Note that each `lists` object in the array will also have a convenience function which operates on itself for read, update & delete. These are also documented below.
 
 ### Lists Create
-Creating a result requires a title and a description. 
+Creating a result requires a title and a description.
 ```javascript
 sharepoint.lists.create({ title : 'My new list', description : 'Some list description' }, function(err, createRes){
   // createRes will be the newly created list as an object { Id : 'someListGUID', title : 'My new list', ...}
 });
 ```  
-    
+
 ### Lists Read
 List Read can take a string as the first param (assumes list Id), or a params object specifying either a guid or title.  
-The list operation already tells us quite a bit about that list, but this read call also returns Fields[] and Items[]. This is different to how the SharePoint API behaves, and is offered as a convenience. 
+The list operation already tells us quite a bit about that list, but this read call also returns Fields[] and Items[]. This is different to how the SharePoint API behaves, and is offered as a convenience.
 ```javascript
 // Get a list by ID - you can find this under the 'Id' property.
 sharepoint.lists.read('someListGUID', function(err, listReadResult){
@@ -95,16 +99,16 @@ sharepoint.lists.read({title : 'some list name' }, function(err, listReadResult)
 sharepoint.lists.list(function(err, listRes){
   var aList = listRes[0];
   aList.read(function(err, aListReadResult){
-    
+
   });
 });
 ```
 ## Lists Update
-Updating requires an ID and a title. Optionally, you can just specify all this in one object. 
+Updating requires an ID and a title. Optionally, you can just specify all this in one object.
 ```javascript
-// Update specifying the Id separately 
+// Update specifying the Id separately
 return sharepoint.lists.update('someListGuid', { Title : 'MyNewTitle' }, function(err, updateResult){
-  // updateResult will be the object you passed in, but not the full list. To get the fully updated object, a subsequent read is needed. 
+  // updateResult will be the object you passed in, but not the full list. To get the fully updated object, a subsequent read is needed.
 });
 
 // Updating specifying the Id in one param
@@ -115,12 +119,12 @@ return sharepoint.lists.update({ Id : 'someListGuid', Title : 'MyNewTitle' }, fu
 sharepoint.lists.list(function(err, listRes){
   var aList = listRes[0];
   aList.update({Title : '' }, function(err){
-    
+
   });
 });
 ```  
 ### Lists Delete
-Delete requires a list Id. Deletion by title is not possible. 
+Delete requires a list Id. Deletion by title is not possible.
 ```javascript
 sharepoint.lists.del('someListId', function(err){
   // Err will indicate if somethign went wrong - there's no second param
@@ -130,30 +134,30 @@ sharepoint.lists.del('someListId', function(err){
 sharepoint.lists.list(function(err, listRes){
   var aList = listRes[0];
   aList.update({Title : '' }, function(err){
-    
+
   });
 });
 ```
-  
+
 ##List Items
-Lists in sharepoint have a collection of items. These are usually another API call away, but as discussed earlier, sharepointer retrieves these upon performing a read() call. 
+Lists in sharepoint have a collection of items. These are usually another API call away, but as discussed earlier, sharepointer retrieves these upon performing a read() call.
 
 ###ListItems List
-To retrieve the items contained within a list, 
+To retrieve the items contained within a list,
 ```javascript
 sharepoint.listItems.list('someListGUID', function(err, itemsUnderThisList){
 
 });
 ```
-Of course, we can also just perform a list read: 
+Of course, we can also just perform a list read:
 ```javascript
 sharepoint.listItems.read('someListGUID', function(err, listReadResult){
   // we now have the items under listReadResult.Items
 });
 ```
-    
+
 ###ListItem Create
-We can create new ListItems within a list using the create function. The responsibility is on the user to ensure all required fields are included prior to creating a listItem, and no extraneous fields are included. SharePoint throws meaningful & useful errors (..for once) if you include incorrect fields here, so it's easy to debug. 
+We can create new ListItems within a list using the create function. The responsibility is on the user to ensure all required fields are included prior to creating a listItem, and no extraneous fields are included. SharePoint throws meaningful & useful errors (..for once) if you include incorrect fields here, so it's easy to debug.
 
 ```javascript
 sharepoint.listItems.create('someListGUID', { Title : 'My new list item', Remember: 'To include all fields' }, function(err, listCreateResult){
@@ -165,42 +169,42 @@ We can also just call .create() on the `Items` property of a list which we've re
 sharepoint.lists.read('someListGUID', function(err, listReadResult){
   // Now that we've read a list, we can create an item under it by running:
   listReadResult.Items.create({ Title : 'My new item' }, function(){
-    
+
   });
   // We could also use listReadResult.createItem() to the same effect
 });
 ```
-    
+
 ###ListItem Read
-As part of reading a ListItem, we also retrieve it's File property, if any exists. This is helpful, because many lists include a file attachment (e.g. Document Libraries). If no file exists, this will simply be `undefined`. 
+As part of reading a ListItem, we also retrieve it's File property, if any exists. This is helpful, because many lists include a file attachment (e.g. Document Libraries). If no file exists, this will simply be `undefined`.
 ```javascript
 sharepoint.listItems.read('someListGUID', 'someListItemId', function(err, singleListItem){
 
 });
 ```
-Of course, we can also just call .read() on a listItem, after we read it's containing list. 
+Of course, we can also just call .read() on a listItem, after we read it's containing list.
 ```javascript
 sharepoint.lists.read('someListGUID', function(err, listReadResult){
   var anItemInThisList = listReadResult.Items[0];
   anItemInThisList.read(function(err, listItem){
-    
+
   });
 });
 ```
 
 ###ListItem Delete
-To delete a ListItem, we can use the del() function. 
+To delete a ListItem, we can use the del() function.
 ```javascript
 sharepoint.listItems.del('someListGUID', 'someListItemId', function(err){
-  
+
 });
 ```
-Of course, we can also just call .del() on a listItem, after we read it's containing list. 
+Of course, we can also just call .del() on a listItem, after we read it's containing list.
 ```javascript
 sharepoint.lists.read('someListGUID', function(err, listReadResult){
   var anItemInThisList = listReadResult.Items[0];
   anItemInThisList.delete(function(err){
-    
+
   });
 });
 ```
@@ -217,15 +221,15 @@ Yet another SharePoint Client. This one:
 * Accepts pull requests :-)
 
 #Tests
-Tests are written in Mocha. Unit tests simply require the integration tests, and `nock` the API they integrate with - thus reducing the amount of test code we need to write. 
+Tests are written in Mocha. Unit tests simply require the integration tests, and `nock` the API they integrate with - thus reducing the amount of test code we need to write.
 ##Running Unit tests
-This includes jshint, and the mocha unit test suite. 
-    
+This includes jshint, and the mocha unit test suite.
+
     # install grunt globally
     npm install grunt-cli -g
     #run the tests
     grunt test
-    
+
 ##Running Integration Tests
 
     #Setup environment variables with your SP creds:

--- a/lib/auth/online.js
+++ b/lib/auth/online.js
@@ -21,9 +21,9 @@ _.mixin({
 });
 
 module.exports = function(client, httpOpts, cb) {
-  
+
   waterfall = [];
-  
+
   // If we're already auth'd, continue as normal with our valid tokens
   if (!client.FedAuth || !client.rtFa){
     waterfall.push(function(waterfallCb){
@@ -33,7 +33,7 @@ module.exports = function(client, httpOpts, cb) {
       samlBody = samlBody.replace('{url}', client.url);
       return waterfallCb(null, samlBody);
     });
-    
+
     // Login with SPOnline using SAML
     waterfall.push(function(samlBody, waterfallCb){
       return request({
@@ -41,7 +41,7 @@ module.exports = function(client, httpOpts, cb) {
         body : samlBody,
         headers : {},
         secureOptions: require('constants').SSL_OP_NO_TLSv1_2,
-        
+
         strictSSL : false,
         url : 'https://login.microsoftonline.com/extSTS.srf',
         timeout: SP_ONLINE_TIMEOUT
@@ -53,7 +53,7 @@ module.exports = function(client, httpOpts, cb) {
           return waterfallCb('Unexpected status code ' + response.statusCode);
         }
         try{
-          body = parser.toJson(body, { object : true });  
+          body = parser.toJson(body, { object : true });
         }catch(err){
           return waterfallCb('Error parsing XML: ' + err.toString());
         }
@@ -68,7 +68,7 @@ module.exports = function(client, httpOpts, cb) {
         return waterfallCb(null, token);
       });
     });
-    
+
     // Exchange the SAML token for a cookie we can auth future SP requests with
     waterfall.push(function(token, waterfallCb){
       var requestOptions = _.extend(SP_ONLINE_SECURITY_OPTIONS, {
@@ -81,7 +81,7 @@ module.exports = function(client, httpOpts, cb) {
         followRedirect: false,
         timeout: SP_ONLINE_TIMEOUT
       });
-      
+
       request.post(requestOptions, function(err, response){
         if (err){
           return waterfallCb(err);
@@ -98,7 +98,7 @@ module.exports = function(client, httpOpts, cb) {
             return;
           }
           parsedCookies[c[0]] = c[1];
-        }); 
+        });
         if (!cookies || !cookies.length || !parsedCookies.FedAuth || !parsedCookies.rtFa){
           return cb('Could not find auth cookies in sharepoint response');
         }
@@ -108,7 +108,7 @@ module.exports = function(client, httpOpts, cb) {
       });
     });
   }
-  
+
   waterfall.push(function(waterfallCb){
     var requestOpts = _.deepExtend({}, httpOpts, client.baseHTTPOptions, SP_ONLINE_SECURITY_OPTIONS, {
       headers: {
@@ -119,6 +119,9 @@ module.exports = function(client, httpOpts, cb) {
       json : httpOpts.json || true,
       timeout: SP_ONLINE_TIMEOUT
     }, httpOpts);
+
+    console.log('requestOpts ', JSON.stringify(requestOpts));
+
     return request(requestOpts, function(error, response, body){
       if (error){
         return waterfallCb(error);
@@ -126,6 +129,6 @@ module.exports = function(client, httpOpts, cb) {
       return waterfallCb(error, response, body);
     });
   });
-  
+
   return async.waterfall(waterfall, cb);
 };

--- a/lib/auth/online.js
+++ b/lib/auth/online.js
@@ -24,90 +24,87 @@ module.exports = function(client, httpOpts, cb) {
 
   waterfall = [];
 
-  // If we're already auth'd, continue as normal with our valid tokens
-  if (!client.FedAuth || !client.rtFa){
-    waterfall.push(function(waterfallCb){
-      var samlBody = _.clone(saml);
-      samlBody = samlBody.replace('{username}', client.auth.username);
-      samlBody = samlBody.replace('{password}', client.auth.password);
-      samlBody = samlBody.replace('{url}', client.url);
-      return waterfallCb(null, samlBody);
+  waterfall.push(function(waterfallCb){
+    var samlBody = _.clone(saml);
+    samlBody = samlBody.replace('{username}', client.auth.username);
+    samlBody = samlBody.replace('{password}', client.auth.password);
+    samlBody = samlBody.replace('{url}', client.url);
+    return waterfallCb(null, samlBody);
+  });
+
+  // Login with SPOnline using SAML
+  waterfall.push(function(samlBody, waterfallCb){
+    return request({
+      method: 'post',
+      body : samlBody,
+      headers : {},
+      secureOptions: require('constants').SSL_OP_NO_TLSv1_2,
+
+      strictSSL : false,
+      url : 'https://login.microsoftonline.com/extSTS.srf',
+      timeout: SP_ONLINE_TIMEOUT
+    }, function(error, response, body){
+      if (error){
+        return waterfallCb(error);
+      }
+      if (response.statusCode !== 200){
+        return waterfallCb('Unexpected status code ' + response.statusCode);
+      }
+      try{
+        body = parser.toJson(body, { object : true });
+      }catch(err){
+        return waterfallCb('Error parsing XML: ' + err.toString());
+      }
+      var samlError = dotty.get(body, "S:Envelope.S:Body.S:Fault"),
+      token = dotty.get(body, "S:Envelope.S:Body.wst:RequestSecurityTokenResponse.wst:RequestedSecurityToken.wsse:BinarySecurityToken.$t");
+      if (samlError){
+        return waterfallCb('Error logging in - SAML fault detected.');
+      }
+      if (!token){
+        return waterfallCb('No token found in response body');
+      }
+      return waterfallCb(null, token);
+    });
+  });
+
+  // Exchange the SAML token for a cookie we can auth future SP requests with
+  waterfall.push(function(token, waterfallCb){
+    var requestOptions = _.extend(SP_ONLINE_SECURITY_OPTIONS, {
+      method: 'post',
+      headers : {
+        'User-Agent': 'fixIISPlease'
+      },
+      body : token,
+      url : client.url + '/_forms/default.aspx?wa=wsignin1.0',
+      followRedirect: false,
+      timeout: SP_ONLINE_TIMEOUT
     });
 
-    // Login with SPOnline using SAML
-    waterfall.push(function(samlBody, waterfallCb){
-      return request({
-        method: 'post',
-        body : samlBody,
-        headers : {},
-        secureOptions: require('constants').SSL_OP_NO_TLSv1_2,
-
-        strictSSL : false,
-        url : 'https://login.microsoftonline.com/extSTS.srf',
-        timeout: SP_ONLINE_TIMEOUT
-      }, function(error, response, body){
-        if (error){
-          return waterfallCb(error);
+    request.post(requestOptions, function(err, response){
+      if (err){
+        return waterfallCb(err);
+      }
+      if (response.statusCode.toString()[0] !== '3'){
+        return waterfallCb('Received unexpected status code from SP token exchange: ' + response.statusCode);
+      }
+      var cookies = response.headers && response.headers['set-cookie'];
+      var parsedCookies = {};
+      _.each(cookies, function(c){
+        // split on first occurance of the = char
+        c = c.split(/=(.+)?/);
+        if (c.length < 2){
+          return;
         }
-        if (response.statusCode !== 200){
-          return waterfallCb('Unexpected status code ' + response.statusCode);
-        }
-        try{
-          body = parser.toJson(body, { object : true });
-        }catch(err){
-          return waterfallCb('Error parsing XML: ' + err.toString());
-        }
-        var samlError = dotty.get(body, "S:Envelope.S:Body.S:Fault"),
-        token = dotty.get(body, "S:Envelope.S:Body.wst:RequestSecurityTokenResponse.wst:RequestedSecurityToken.wsse:BinarySecurityToken.$t");
-        if (samlError){
-          return waterfallCb('Error logging in - SAML fault detected.');
-        }
-        if (!token){
-          return waterfallCb('No token found in response body');
-        }
-        return waterfallCb(null, token);
+        parsedCookies[c[0]] = c[1];
       });
+      if (!cookies || !cookies.length || !parsedCookies.FedAuth || !parsedCookies.rtFa){
+        return cb('Could not find auth cookies in sharepoint response');
+      }
+      client.FedAuth = parsedCookies.FedAuth;
+      client.rtFa = parsedCookies.rtFa;
+      return waterfallCb(null);
     });
-
-    // Exchange the SAML token for a cookie we can auth future SP requests with
-    waterfall.push(function(token, waterfallCb){
-      var requestOptions = _.extend(SP_ONLINE_SECURITY_OPTIONS, {
-        method: 'post',
-        headers : {
-          'User-Agent': 'fixIISPlease'
-        },
-        body : token,
-        url : client.url + '/_forms/default.aspx?wa=wsignin1.0',
-        followRedirect: false,
-        timeout: SP_ONLINE_TIMEOUT
-      });
-
-      request.post(requestOptions, function(err, response){
-        if (err){
-          return waterfallCb(err);
-        }
-        if (response.statusCode.toString()[0] !== '3'){
-          return waterfallCb('Received unexpected status code from SP token exchange: ' + response.statusCode);
-        }
-        var cookies = response.headers && response.headers['set-cookie'];
-        var parsedCookies = {};
-        _.each(cookies, function(c){
-          // split on first occurance of the = char
-          c = c.split(/=(.+)?/);
-          if (c.length < 2){
-            return;
-          }
-          parsedCookies[c[0]] = c[1];
-        });
-        if (!cookies || !cookies.length || !parsedCookies.FedAuth || !parsedCookies.rtFa){
-          return cb('Could not find auth cookies in sharepoint response');
-        }
-        client.FedAuth = parsedCookies.FedAuth;
-        client.rtFa = parsedCookies.rtFa;
-        return waterfallCb(null);
-      });
-    });
-  }
+  });
 
   waterfall.push(function(waterfallCb){
     //Remove the body from SP_ONLINE_SECURITY_OPTIONS before we deepExtend so we can update items.

--- a/lib/auth/online.js
+++ b/lib/auth/online.js
@@ -110,7 +110,12 @@ module.exports = function(client, httpOpts, cb) {
   }
 
   waterfall.push(function(waterfallCb){
-    var requestOpts = _.deepExtend({}, httpOpts, client.baseHTTPOptions, SP_ONLINE_SECURITY_OPTIONS, {
+    //Remove the body from SP_ONLINE_SECURITY_OPTIONS before we deepExtend so we can update items.
+    //Strings and JSON don't mix when doing deepExtends
+    if(SP_ONLINE_SECURITY_OPTIONS.hasOwnProperty('body')) {
+      delete SP_ONLINE_SECURITY_OPTIONS.body;
+    }
+    var requestOpts = _.deepExtend({}, client.baseHTTPOptions, SP_ONLINE_SECURITY_OPTIONS, {
       headers: {
         'Cookie': 'FedAuth=' + client.FedAuth + '; rtFa=' + client.rtFa,
         'Accept' : 'application/json; odata=verbose',
@@ -119,8 +124,6 @@ module.exports = function(client, httpOpts, cb) {
       json : httpOpts.json || true,
       timeout: SP_ONLINE_TIMEOUT
     }, httpOpts);
-
-    console.log('requestOpts ', JSON.stringify(requestOpts));
 
     return request(requestOpts, function(error, response, body){
       if (error){

--- a/lib/client.js
+++ b/lib/client.js
@@ -11,8 +11,11 @@ module.exports = function(params){
   this.auth.domain = params.domain || '';
   this.auth.type = params.type || 'basic';
   this.verbose = (typeof params.verbose === 'boolean') ? params.verbose : false;
+  this.fieldValuesAsText = (typeof params.fieldValuesAsText === 'boolean') ? params.fieldValuesAsText : false;
+  this.filterFields = params.filterFields || null; // an array of objects [{"field": one, "value": 1}, {"field": two, "value": 2}]
+  this.selectFields = params.selectFields || null;  //straight array ["one", "two"]
   
-  // We later set up http requests with this options object, either basic auth (goes in 'auth'), 
+  // We later set up http requests with this options object, either basic auth (goes in 'auth'),
   // or NTLM (goes in an Authorization header)
   this.baseHTTPOptions = {
     headers : {
@@ -23,7 +26,7 @@ module.exports = function(params){
     proxy : params.proxy || undefined
   };
   this.BASE_LIST_URL = '/_api/web/lists';
-  
+
   return {
     login : require('./login')(this),
     lists : require('./objects/lists')(this),

--- a/lib/client.js
+++ b/lib/client.js
@@ -31,7 +31,6 @@ module.exports = function(params){
     this.BASE_LIST_URL = '/' + this.siteContext + this.BASE_LIST_URL;
   }
 
-
   return {
     login : require('./login')(this),
     lists : require('./objects/lists')(this),

--- a/lib/client.js
+++ b/lib/client.js
@@ -12,9 +12,10 @@ module.exports = function(params){
   this.auth.type = params.type || 'basic';
   this.verbose = (typeof params.verbose === 'boolean') ? params.verbose : false;
   this.fieldValuesAsText = (typeof params.fieldValuesAsText === 'boolean') ? params.fieldValuesAsText : false;
-  this.filterFields = params.filterFields || null; // an array of objects [{"field": one, "value": 1}, {"field": two, "value": 2}]
-  this.selectFields = params.selectFields || null;  //straight array ["one", "two"]
-  
+  this.filterFields = params.filterFields || null;  //an array of objects ["{\"field\": \"one\", \"value\": \"1\"}", "{\"field\": \"two\", \"value\": \"2\"}"]
+  this.selectFields = params.selectFields || null;  //array ["one", "two"]
+  this.expandFields = params.expandFields || null; //array ["one", "two"]
+
   // We later set up http requests with this options object, either basic auth (goes in 'auth'),
   // or NTLM (goes in an Authorization header)
   this.baseHTTPOptions = {
@@ -26,6 +27,10 @@ module.exports = function(params){
     proxy : params.proxy || undefined
   };
   this.BASE_LIST_URL = '/_api/web/lists';
+  if (this.siteContext && this.siteContext !== 'web'){
+    this.BASE_LIST_URL = '/' + this.siteContext + this.BASE_LIST_URL;
+  }
+
 
   return {
     login : require('./login')(this),

--- a/lib/objects/listItems.js
+++ b/lib/objects/listItems.js
@@ -3,6 +3,8 @@ _ = require('underscore');
 
 module.exports = function(client){
   var doRequest = require('../util/doRequest')(client),
+  filter = '',
+  select = '',
   conveniences,
   crudl = {
     // We're the only one calling this function, so relatively safe in our params
@@ -20,10 +22,52 @@ module.exports = function(client){
       if (!listId || !itemId){
         return cb('Error reading - unspecified listId or itemId');
       }
-      
+
       var host = client.BASE_LIST_URL + "(guid'" + listId + "')" + "/Items(" + itemId + ")",
       fileHost = host + '/File';
-      
+
+      //Show all values as text
+      if(client.fieldValuesAsText) {
+        host += '/FieldValuesAsText';
+      }
+      //build filter string
+      if(client.filterFields.hasOwnProperty(length)) {
+        filter +='$filter=';
+        var filterString = '';
+        if(client.filterFields.length === 1) {
+          filterString = client.filterFields[0]['field'] + '%20eq%20' + "'" + client.filterFields[0]['value'] + "'";
+        }
+        else {
+          for(i=0;i<client.filterFields.length;i++) {
+            if(i === 0) {
+              filterString = '(' + client.filterFields[0]['field'] + '%20eq%20' + "'" + client.filterFields[0]['value'] + "')";
+            }
+            else {
+              filterString += '%20and%20(' + client.filterFields[0]['field'] + '%20eq%20' + "'" + client.filterFields[0]['value'] + "')";
+            }
+          }
+        }
+        filter += filterString;
+      }
+      //build select string
+      if(client.selectFields.hasOwnProperty(length)) {
+        select += '?';
+        client.selectFields.foreach(function(fields) {
+           select += fields + ',';
+        });
+        select = select.slice(0, -1);
+      }
+      //Add filter and / or select query parameters to host variable
+      if(filter.length > 0) {
+        host += '?' + filter;
+        if(select.length > 0) {
+          host += '&' + select;
+        }
+      }
+      else if(select.length > 0) {
+        host += '?' + select;
+      }
+
       async.parallel({
         item : async.apply(doRequest, host),
         file : async.apply(doRequest, fileHost)
@@ -33,7 +77,7 @@ module.exports = function(client){
         }
         var item = response.item;
         item.File = response.File;
-        
+
         item = conveniences('ListItem', item, listId);
         return cb(null, item);
       });
@@ -42,7 +86,7 @@ module.exports = function(client){
       if (!listId || !listItem){
         return cb('No list or listItem specifided');
       }
-      
+
       var host = client.BASE_LIST_URL + "(guid'" + listId + "')" + "/Items";
       listItem = _.extend({
         "__metadata" : {
@@ -70,7 +114,7 @@ module.exports = function(client){
       if (!listId || !itemId){
         return cb('Error deleting - unspecified listId or itemId');
       }
-      
+
       var host = client.BASE_LIST_URL + "(guid'" + listId + "')" + "/Items(" + itemId + ")";
       return doRequest({
         url : host,

--- a/lib/objects/listItems.js
+++ b/lib/objects/listItems.js
@@ -3,13 +3,18 @@ _ = require('underscore');
 
 module.exports = function(client){
   var doRequest = require('../util/doRequest')(client),
-  filter = '',
-  select = '',
+  urlBuilder = require('../util/urlBuilderTools'),
   conveniences,
   crudl = {
     // We're the only one calling this function, so relatively safe in our params
     list : function(listId, cb){
       var host = client.BASE_LIST_URL + "(guid'" + listId + "')" + "/Items";
+
+      //FieldValuesAsText is not supported here by Sharepoint, Append filterFields
+      // and / or selectFields  and / or expandFields to host
+      host = urlBuilder.augmentURL(host, false, client.filterFields, client.selectFields, client.expandFields);
+
+      console.log('list Items URL ' + host);
       return doRequest(host, function(err, items){
         if (err){
           return cb(err);
@@ -26,47 +31,10 @@ module.exports = function(client){
       var host = client.BASE_LIST_URL + "(guid'" + listId + "')" + "/Items(" + itemId + ")",
       fileHost = host + '/File';
 
-      //Show all values as text
-      if(client.fieldValuesAsText) {
-        host += '/FieldValuesAsText';
-      }
-      //build filter string
-      if(client.filterFields.hasOwnProperty(length)) {
-        filter +='$filter=';
-        var filterString = '';
-        if(client.filterFields.length === 1) {
-          filterString = client.filterFields[0]['field'] + '%20eq%20' + "'" + client.filterFields[0]['value'] + "'";
-        }
-        else {
-          for(i=0;i<client.filterFields.length;i++) {
-            if(i === 0) {
-              filterString = '(' + client.filterFields[0]['field'] + '%20eq%20' + "'" + client.filterFields[0]['value'] + "')";
-            }
-            else {
-              filterString += '%20and%20(' + client.filterFields[0]['field'] + '%20eq%20' + "'" + client.filterFields[0]['value'] + "')";
-            }
-          }
-        }
-        filter += filterString;
-      }
-      //build select string
-      if(client.selectFields.hasOwnProperty(length)) {
-        select += '?';
-        client.selectFields.foreach(function(fields) {
-           select += fields + ',';
-        });
-        select = select.slice(0, -1);
-      }
-      //Add filter and / or select query parameters to host variable
-      if(filter.length > 0) {
-        host += '?' + filter;
-        if(select.length > 0) {
-          host += '&' + select;
-        }
-      }
-      else if(select.length > 0) {
-        host += '?' + select;
-      }
+      //Append fieldValuesAsText (filters are not supported by Sharepoint at the item level)
+      // and / or selectFields  and / or expandFields to host
+      host = urlBuilder.augmentURL(host, client.fieldValuesAsText, null, client.selectFields, client.expandFields);
+      console.log('read Items URL ' + host);
 
       async.parallel({
         item : async.apply(doRequest, host),
@@ -110,6 +78,33 @@ module.exports = function(client){
         return cb(null, createResult);
       });
     },
+    update : function(listId, listItem, cb){
+      if (!listId || !listItem){
+        return cb('No list or listItem specifided');
+      }
+
+      var host = client.BASE_LIST_URL + "(guid'" + listId + "')" + "/Items(" + listItem.itemId + ")";
+      console.log('-----sharepointer-objects-listItems host: ' + host);
+
+      //remove the itemId property as we shouldn't need it in the post data
+      delete listItem['itemId'];
+      return doRequest({
+        url : host,
+        method : 'POST',
+        body : JSON.stringify(listItem),
+        headers: {
+          'X-RequestDigest': client.baseContext,
+          'If-Match': '*',
+          'X-HTTP-Method': 'MERGE'
+        }
+      }, function(err, updateResult){
+        if (err){
+          return cb(err);
+        }
+        updateResult = conveniences('ListItem', updateResult, listId);
+        return cb(null, updateResult);
+      });
+    },
     del : function(listId, itemId, cb){
       if (!listId || !itemId){
         return cb('Error deleting - unspecified listId or itemId');
@@ -121,7 +116,7 @@ module.exports = function(client){
         method : 'POST',
         headers: {
           'X-RequestDigest': client.baseContext,
-          'IF-MATCH': '*',
+          'If-Match': '*',
           'X-HTTP-Method': 'DELETE'
         }
       }, function(err, createResult){

--- a/lib/objects/listItems.js
+++ b/lib/objects/listItems.js
@@ -14,7 +14,6 @@ module.exports = function(client){
       // and / or selectFields  and / or expandFields to host
       host = urlBuilder.augmentURL(host, false, client.filterFields, client.selectFields, client.expandFields);
 
-      console.log('list Items URL ' + host);
       return doRequest(host, function(err, items){
         if (err){
           return cb(err);
@@ -34,7 +33,6 @@ module.exports = function(client){
       //Append fieldValuesAsText (filters are not supported by Sharepoint at the item level)
       // and / or selectFields  and / or expandFields to host
       host = urlBuilder.augmentURL(host, client.fieldValuesAsText, null, client.selectFields, client.expandFields);
-      console.log('read Items URL ' + host);
 
       async.parallel({
         item : async.apply(doRequest, host),
@@ -84,14 +82,13 @@ module.exports = function(client){
       }
 
       var host = client.BASE_LIST_URL + "(guid'" + listId + "')" + "/Items(" + listItem.itemId + ")";
-      console.log('-----sharepointer-objects-listItems host: ' + host);
 
-      //remove the itemId property as we shouldn't need it in the post data
+      //remove the itemId property as we don't need it in the post data
       delete listItem['itemId'];
       return doRequest({
         url : host,
         method : 'POST',
-        body : JSON.stringify(listItem),
+        body : listItem,
         headers: {
           'X-RequestDigest': client.baseContext,
           'If-Match': '*',

--- a/lib/objects/lists.js
+++ b/lib/objects/lists.js
@@ -4,12 +4,13 @@ async = require('async');
 module.exports = function(client) {
   var doRequest = require('../util/doRequest')(client),
   listItems = require('./listItems')(client),
+  urlBuilder = require('../util/urlBuilderTools'),
   conveniences;
 
   var crudl = {
     readOrList: function(params, cb) {
       var isReadOperation = true,
-      guid, name, host;
+      guid, name, host, fieldsHost;
       if (_.isFunction(params)) {
         cb = params;
         params = undefined;
@@ -24,14 +25,22 @@ module.exports = function(client) {
         guid = params;
       }
 
-      // Spot the pattern! Yep, you got it - there isn't really one. Thanks, MSFT. 
+      // Spot the pattern! Yep, you got it - there isn't really one. Thanks, MSFT.
       if (guid) {
         // I have no idea why GUID follows some semblence of oData protocol..
         host += "(guid'" + guid + "')";
       } else if (name) {
-        // by by name just ignores it. WTF is filter doing where the resource name should be. Bro, you don't even REST. 
+        // by by name just ignores it. WTF is filter doing where the resource name should be. Bro, you don't even REST.
         host += "/getbytitle('" + name + "')";
       }
+
+      //Don't mess with fieldsHost
+      fieldsHost = host + '/Fields';
+
+      // FieldValuesAsText is not supported here by Sharepoint, Append filterFields
+      // and / or selectFields  and /or expandFields to host
+      host = urlBuilder.augmentURL(host, false, client.filterFields, client.selectFields, client.expandFields);
+      console.log('read List URL ' + host);
 
       if (!isReadOperation) {
         return doRequest(host, function(err, lists) {
@@ -42,10 +51,11 @@ module.exports = function(client) {
           return cb(null, lists);
         });
       }
+      console.log('lists URL ' + host);
 
       return async.parallel({
         List: async.apply(doRequest, host),
-        Fields: async.apply(doRequest, host + '/Fields'),
+        Fields: async.apply(doRequest, fieldsHost),
         Items: async.apply(listItems.list, guid)
       }, function(err, combinedReadResult) {
         if (err) {
@@ -147,7 +157,7 @@ module.exports = function(client) {
 
 
       return doRequest({
-        json: listToUpdate,
+        data: listToUpdate,
         method: 'POST',
         headers: {
           'X-RequestDigest': client.baseContext,
@@ -162,7 +172,7 @@ module.exports = function(client) {
         return cb(null, listToUpdate);
       });
     },
-    // A passthru to listItems.js for conveniences.js 
+    // A passthru to listItems.js for conveniences.js
     createItem : listItems.create
   };
   crudl['delete'] = crudl.del;

--- a/lib/objects/lists.js
+++ b/lib/objects/lists.js
@@ -40,7 +40,6 @@ module.exports = function(client) {
       // FieldValuesAsText is not supported here by Sharepoint, Append filterFields
       // and / or selectFields  and /or expandFields to host
       host = urlBuilder.augmentURL(host, false, client.filterFields, client.selectFields, client.expandFields);
-      console.log('read List URL ' + host);
 
       if (!isReadOperation) {
         return doRequest(host, function(err, lists) {
@@ -51,7 +50,6 @@ module.exports = function(client) {
           return cb(null, lists);
         });
       }
-      console.log('lists URL ' + host);
 
       return async.parallel({
         List: async.apply(doRequest, host),
@@ -157,7 +155,7 @@ module.exports = function(client) {
 
 
       return doRequest({
-        data: listToUpdate,
+        body: listToUpdate,
         method: 'POST',
         headers: {
           'X-RequestDigest': client.baseContext,

--- a/lib/util/doRequest.js
+++ b/lib/util/doRequest.js
@@ -10,6 +10,7 @@ module.exports = function(client){
     if (!client.httpClient){
       return cb('Error finding login information - please call login() again');
     }
+
     client.httpClient(client, opts, function(err, response, body){
       if (err){
         return cb(err);
@@ -21,10 +22,10 @@ module.exports = function(client){
         }
         return cb({message : msg, body : body, statusCode : response.statusCode});
       }
-      
+
       body = makeSharepointResponsesLessAwful(body);
       body = verbosityFilter(body, opts.url);
-      
+
       //TODO: Apply conveniences Here
       return cb(null, body);
     });

--- a/lib/util/urlBuilderTools.js
+++ b/lib/util/urlBuilderTools.js
@@ -1,0 +1,101 @@
+/*
+ This function is used to add parameters to a URL used to call Sharepoint.
+ -/FieldValuesAsText will make all fields for an item show as a text value instead of an identifier.
+ -filter fields are used to limit items returned based on value of one or more fields
+ -select fields are used to limit the fields returned
+ -expand fields are used to "JOIN" a lookup list to the list currently being Read / Listed
+ */
+exports.augmentURL = function(url, fieldValuesAsText, filterFields, selectFields, expandFields) {
+  var finalURL = url.trim(),
+  filter = '',
+  filterField = '',
+  filterString = '',
+  select = '';
+  expand = '';
+
+  //Show all values as text
+  if(fieldValuesAsText) {
+    finalURL += '/FieldValuesAsText';
+  }
+
+  //build filter string - used to get items with a specific value for a field
+  if(filterFields !== null && filterFields.hasOwnProperty('length')) {
+    filter = '$filter=';
+    if(filterFields.length === 1) {
+      try {
+        filterField = JSON.parse(filterFields[0]);
+      }
+      catch(e) {
+        console.log('Unable to parse filterFields, expecting {"field":"Field1", "value":"Value1"}');
+      }
+      filterString = filterField['field'] + '%20eq%20' + "'" + filterField['value'] + "'";
+    }
+    else {
+      for(i=0;i<filterFields.length;i++) {
+        try {
+          filterField = JSON.parse(filterFields[i]);
+        }
+        catch(e) {
+          console.log('Unable to parse filterFields, expecting {"field":"Field1", "value":"Value1"}');
+        }
+        if(i === 0) {
+          filterString = '(' + filterField['field'].trim() + '%20eq%20' + "'" + filterField['value'].trim() + "')";
+        }
+        else {
+          filterString += '%20and%20(' + filterField['field'].trim() + '%20eq%20' + "'" + filterField['value'].trim() + "')";
+        }
+      }
+    }
+    filter += filterString;
+  }
+
+  //build select string - used to tell Sharepoint which fields to return in response to REST call
+  if(selectFields !== null && selectFields.constructor === Array) {
+    select = '$select=';
+    selectFields.forEach(function(fields) {
+      try {
+       select += fields.toString().trim() + ',';
+     }
+     catch(e) {
+       console.log('Unable to parse selectFields.');
+     }
+    });
+    select = select.slice(0, -1);
+  }
+
+  //build expand string - used to tell Sharepoint to provide detail on value
+  if(expandFields !== null && expandFields.constructor === Array) {
+    expand = '$expand=';
+    expandFields.forEach(function(fields) {
+      try {
+       expand += fields.toString().trim() + ',';
+     }
+     catch(e) {
+       console.log('Unable to parse expandFields.');
+     }
+    });
+    expand = expand.slice(0, -1);
+  }
+
+  //Append filter and / or select query parameters to finalURL
+  if(filter.length > 0) {
+    finalURL += '?' + filter;
+    if(select.length > 0) {
+      finalURL += '&' + select;
+    }
+    if(expand.length > 0) {
+      finalURL += '&' + expand;
+    }
+  }
+  else if(select.length > 0) {
+    finalURL += '?' + select;
+    if(expand.length > 0) {
+      finalURL += '&' + expand;
+    }
+  }
+  else if(expand.length > 0) {
+      finalURL += '?' + expand;
+  }
+
+  return finalURL;
+};

--- a/lib/util/urlBuilderTools.js
+++ b/lib/util/urlBuilderTools.js
@@ -50,7 +50,7 @@ exports.augmentURL = function(url, fieldValuesAsText, filterFields, selectFields
   }
 
   //build select string - used to tell Sharepoint which fields to return in response to REST call
-  if(selectFields !== null && selectFields.constructor === Array) {
+  if(selectFields && selectFields !== null && selectFields.constructor === Array) {
     select = '$select=';
     selectFields.forEach(function(fields) {
       try {
@@ -64,7 +64,7 @@ exports.augmentURL = function(url, fieldValuesAsText, filterFields, selectFields
   }
 
   //build expand string - used to tell Sharepoint to provide detail on value
-  if(expandFields !== null && expandFields.constructor === Array) {
+  if(expandFields && expandFields !== null && expandFields.constructor === Array) {
     expand = '$expand=';
     expandFields.forEach(function(fields) {
       try {


### PR DESCRIPTION
Sharepoint's $filter, $select, $expand and FieldValuesAsText functionalities have been implemented.
A function to update list items was added.
Removed code where '/sites' was being added to the BASE_LIST_URL in client.js that was changing the context enough to cause updates to list items to fail.
Check for and remove body property from SP_ONLINE_SECURITY_OPTIONS in online.js as this interferes with getting the body needed to update items in the deepExtend function.

Added functionality was successfully tested using Sharepoint provided by the Office 365 trial.

Also fixed bug that was allowing invalid credentials to use cookies attained previously from the use of valid credentials.
