### PR TITLE
Support multiple client users

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,24 @@
 module.exports = function(grunt) {
 
   grunt.initConfig({
+    concurrent: {
+      debug_integration: ['node-inspector', 'open:debug','shell:integrate_debug'],
+      options: {
+        logConcurrentOutput: true
+      }
+    },
+    'node-inspector': { dev: {} },
     jshint: {
       all: ['index.js', 'lib/**/*.js', 'test/**/**/*.js']
+    },
+    open: {
+      debug: {
+        path: 'http://127.0.0.1:8080/debug?port=5858',
+        app: 'Google Chrome'
+      }
+    },
+    shell: {
+      integrate_debug : './node_modules/mocha/bin/mocha --debug-brk -A -u exports --recursive -t 25000 ./test/integration '
     },
     unit: ['export SP_USERNAME="foo"; export SP_PASSWORD="foo"; export SP_AUTH_TYPE="basic"; export SP_HOST="https://www.example.com"', './node_modules/mocha/bin/mocha -A -u exports --recursive -t 10000 ./test/unit'],
     integrate : ['./node_modules/mocha/bin/mocha -A -u exports --recursive -t 25000 ./test/integration ']
@@ -10,8 +26,13 @@ module.exports = function(grunt) {
 
   grunt.loadNpmTasks('grunt-fh-build');
   grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-concurrent');
+  grunt.loadNpmTasks('grunt-node-inspector');
+  grunt.loadNpmTasks('grunt-open');
+  grunt.loadNpmTasks('grunt-shell');
   grunt.registerTask('test', ['jshint', 'fh:unit']);
   grunt.registerTask('integration', ['fh:integrate']);
   grunt.registerTask('dist', ['test', 'fh:dist']);
   grunt.registerTask('default', 'test');
+  grunt.registerTask('debug_integration','concurrent:debug_integration');
 };

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sharepoint.login(function(err){
 });
 ```
 
-##Paramaters
+## Parameters
 When initialising Sharepoint, there are a number of optional params which can be specified at init. Here are their defaults & descriptions
 ```javascript
 var sharepoint = require('sharepoint')({
@@ -40,7 +40,7 @@ var sharepoint = require('sharepoint')({
   verbose : false, // Set to true to stop filtering responses, instead returning everything
   proxy : undefined, // set to string hostname of proxy if running through one
   strictSSL : true, // set to false if connecting to SP instance with self-signed cert
-  federatedAuthUrl : 'http://mysamlloginservice.com', // only set for auth type 'onlinesaml', the URL of the SAML service which issues assertions to forward to the SHarePoint login URL
+  federatedAuthUrl : 'http://mysamlloginservice.com', // only set for auth type 'onlinesaml', the URL of the SAML service which issues assertions to forward to the SharePoint login URL
   fieldValuesAsText : true, //Return Lookup Field Values as Text for Items
   filterFields : ["{\"field\": \"field1\", \"value\": \"value1\"}"], //Filter Items in List based on field value(s) $filter=
   selectFields : ['field1', 'field2'], //Only return List or Item data for fields specified $select=
@@ -140,10 +140,10 @@ sharepoint.lists.list(function(err, listRes){
 });
 ```
 
-##List Items
+## List Items
 Lists in sharepoint have a collection of items. These are usually another API call away, but as discussed earlier, sharepointer retrieves these upon performing a read() call.
 
-###ListItems List
+### ListItems List
 To retrieve the items contained within a list,
 ```javascript
 sharepoint.listItems.list('someListGUID', function(err, itemsUnderThisList){
@@ -157,7 +157,7 @@ sharepoint.listItems.read('someListGUID', function(err, listReadResult){
 });
 ```
 
-###ListItem Create
+### ListItem Create
 We can create new ListItems within a list using the create function. The responsibility is on the user to ensure all required fields are included prior to creating a listItem, and no extraneous fields are included. SharePoint throws meaningful & useful errors (..for once) if you include incorrect fields here, so it's easy to debug.
 
 ```javascript
@@ -176,7 +176,7 @@ sharepoint.lists.read('someListGUID', function(err, listReadResult){
 });
 ```
 
-###ListItem Read
+### ListItem Read
 As part of reading a ListItem, we also retrieve it's File property, if any exists. This is helpful, because many lists include a file attachment (e.g. Document Libraries). If no file exists, this will simply be `undefined`.
 ```javascript
 sharepoint.listItems.read('someListGUID', 'someListItemId', function(err, singleListItem){
@@ -193,7 +193,7 @@ sharepoint.lists.read('someListGUID', function(err, listReadResult){
 });
 ```
 
-##ListItem Update
+## ListItem Update
 To update a ListItem, we use the update() function.
 ```javascript
 var listItemData {
@@ -205,7 +205,7 @@ var listItemData {
 sharepoint.listItems.update('someListGUID', listItemData, function(res));
 ```
 
-###ListItem Delete
+### ListItem Delete
 To delete a ListItem, we can use the del() function.
 ```javascript
 sharepoint.listItems.del('someListGUID', 'someListItemId', function(err){
@@ -222,11 +222,11 @@ sharepoint.lists.read('someListGUID', function(err, listReadResult){
 });
 ```
 
-#Why another Sharepoint Client?
+# Why another Sharepoint Client?
 Yet another SharePoint Client. This one:
 
 * Has test coverage
-* Isn't written in CofeeScript
+* Isn't written in CoffeeScript
 * Supports multiple authentication schemas - currently:
   * NTLM
   * Basic
@@ -234,22 +234,23 @@ Yet another SharePoint Client. This one:
   * Online with SAML SSO (Sharepoint 365 to Federated SAML SSO flow)
 * Accepts pull requests :-)
 
-#Tests
+# Tests
 Tests are written in Mocha. Unit tests simply require the integration tests, and `nock` the API they integrate with - thus reducing the amount of test code we need to write.
-##Running Unit tests
+## Running Unit tests
 This includes jshint, and the mocha unit test suite.
-
-    # install grunt globally
-    npm install grunt-cli -g
-    #run the tests
-    grunt test
-
-##Running Integration Tests
-
-    #Setup environment variables with your SP creds:
-    export SP_USERNAME=YOUR_USERNAME
-    export SP_PASSWORD=YOUR_PASSWORD
-    export SP_HOST=https://your_sp_hostname.com
-    export SP_AUTH_TYPE=(ntlm|basic|online|onlinesaml)
-    #Then run the tests:
-    grunt integration
+```
+# install grunt globally
+npm install grunt-cli -g
+#run the tests
+grunt test
+```
+## Running Integration Tests
+```
+#Setup environment variables with your SP creds:
+export SP_USERNAME=YOUR_USERNAME
+export SP_PASSWORD=YOUR_PASSWORD
+export SP_HOST=https://your_sp_hostname.com
+export SP_AUTH_TYPE=(ntlm|basic|online|onlinesaml)
+#Then run the tests:
+grunt integration
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Node.js SharePoint Client.
 var sharepoint = require('sharepoint')({
   username : 'someusername',
   password : 'somepassword',
-  // Authentication type - current valid values: ntlm, basic, online
+  // Authentication type - current valid values: ntlm, basic, online,onlinesaml
   type : 'ntlm',
   url : 'https://someSharepointHostname.com'
 });

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ var sharepoint = require('sharepoint')({
   proxy : undefined, // set to string hostname of proxy if running through one
   strictSSL : true, // set to false if connecting to SP instance with self-signed cert
   federatedAuthUrl : 'http://mysamlloginservice.com', // only set for auth type 'onlinesaml', the URL of the SAML service which issues assertions to forward to the SharePoint login URL
+  rtFa: <token>,// an optional parameter to set rtFa token value - used if you've previously authenticated and stored the tokens (captured from the rtFA property after logging in)
+  FedAuth:<token>, // an optional parameter to set FedAuth token value - used if you've previously authenticated and stored the tokens (captured from the FedAuth property after logging in)
   fieldValuesAsText : true, //Return Lookup Field Values as Text for Items
   filterFields : ["{\"field\": \"field1\", \"value\": \"value1\"}"], //Filter Items in List based on field value(s) $filter=
   selectFields : ['field1', 'field2'], //Only return List or Item data for fields specified $select=

--- a/lib/auth/onlinesaml.js
+++ b/lib/auth/onlinesaml.js
@@ -6,7 +6,8 @@ samlLogin = require('./online/samlLogin'),
 samlResponse = require('./online/samlResponse'),
 samlAssertionResponse = require('./online/samlAssertionResponse'),
 samlTokenToCookie = require('./online/samlTokenToCookie'),
-authenticatedRequestClient = require('./online/authenticatedRequestClient');
+authenticatedRequestClient = require('./online/authenticatedRequestClient'),
+assert=require('assert');
 
 _.mixin({
   deepExtend: underscoreDeepExtend(_)
@@ -16,6 +17,7 @@ module.exports = function(client, httpOpts, cb) {
   var waterfall = [];
   
   if (!client.FedAuth || !client.rtFa){
+    assert.ok(client.federatedAuthUrl, "Federated Auth URL is required when using onlinesaml");
     waterfall.push(async.apply(getSamlBody, client, httpOpts, client.federatedAuthUrl, 'urn:federation:MicrosoftOnline', null));
     waterfall.push(samlLogin);
     waterfall.push(samlAssertionResponse);

--- a/lib/client.js
+++ b/lib/client.js
@@ -18,6 +18,8 @@ module.exports = function(params){
   clientObj.filterFields = params.filterFields || null; // an array of objects [{"field": one, "value": 1}, {"field": two, "value": 2}]
   clientObj.selectFields = params.selectFields || null;  //array ["one", "two"]
   clientObj.expandFields = params.expandFields || null; //array ["one", "two"]
+  clientObj.FedAuth=params.FedAuth||null;
+  clientObj.rtFa=params.rtFa||null;
 
   // We later set up http requests with clientObj options object, either basic auth (goes in 'auth'),
   // or NTLM (goes in an Authorization header)

--- a/lib/client.js
+++ b/lib/client.js
@@ -2,25 +2,26 @@ module.exports = function(params){
   if (!params.username || !params.password || !params.url){
     throw new Error('SharePoint client needs a username, password and instance URL');
   }
-  this.url = params.url;
-  this.federatedAuthUrl = params.federatedAuthUrl;
-  this.auth = {};
-  this.siteContext = params.context || 'web';
-  this.auth.username = params.username;
-  this.auth.password = params.password;
-  this.auth.workstation = params.workstation || '';
-  this.auth.domain = params.domain || '';
-  this.auth.type = params.type || 'basic';
-  this.auth.custom = params.authenticator;
-  this.verbose = (typeof params.verbose === 'boolean') ? params.verbose : false;
-  this.fieldValuesAsText = (typeof params.fieldValuesAsText === 'boolean') ? params.fieldValuesAsText : false;
-  this.filterFields = params.filterFields || null;  //an array of objects ["{\"field\": \"one\", \"value\": \"1\"}", "{\"field\": \"two\", \"value\": \"2\"}"]
-  this.selectFields = params.selectFields || null;  //array ["one", "two"]
-  this.expandFields = params.expandFields || null; //array ["one", "two"]
+  var clientObj={};
+  clientObj.url = params.url;
+  clientObj.federatedAuthUrl = params.federatedAuthUrl;
+  clientObj.auth = {};
+  clientObj.siteContext = params.context || 'web';
+  clientObj.auth.username = params.username;
+  clientObj.auth.password = params.password;
+  clientObj.auth.workstation = params.workstation || '';
+  clientObj.auth.domain = params.domain || '';
+  clientObj.auth.type = params.type || 'basic';
+  clientObj.auth.custom = params.authenticator;
+  clientObj.verbose = (typeof params.verbose === 'boolean') ? params.verbose : false;
+  clientObj.fieldValuesAsText = (typeof params.fieldValuesAsText === 'boolean') ? params.fieldValuesAsText : false;
+  clientObj.filterFields = params.filterFields || null; // an array of objects [{"field": one, "value": 1}, {"field": two, "value": 2}]
+  clientObj.selectFields = params.selectFields || null;  //array ["one", "two"]
+  clientObj.expandFields = params.expandFields || null; //array ["one", "two"]
 
-  // We later set up http requests with this options object, either basic auth (goes in 'auth'),
+  // We later set up http requests with clientObj options object, either basic auth (goes in 'auth'),
   // or NTLM (goes in an Authorization header)
-  this.baseHTTPOptions = {
+  clientObj.baseHTTPOptions = {
     headers : {
       'Accept' : 'application/json; odata=verbose',
       'Content-Type' : 'application/json; odata=verbose'
@@ -28,14 +29,14 @@ module.exports = function(params){
     strictSSL: (typeof params.strictSSL === 'boolean') ? params.strictSSL : true,
     proxy : params.proxy || undefined
   };
-  this.BASE_LIST_URL = '/_api/web/lists';
-  if (this.siteContext && this.siteContext !== 'web'){
-    this.BASE_LIST_URL = '/' + this.siteContext + this.BASE_LIST_URL;
+  clientObj.BASE_LIST_URL = '/_api/web/lists';
+  if (clientObj.siteContext && clientObj.siteContext !== 'web'){
+    clientObj.BASE_LIST_URL = '/' + clientObj.siteContext + clientObj.BASE_LIST_URL;
   }
 
   return {
-    login : require('./login')(this),
-    lists : require('./objects/lists')(this),
-    listItems : require('./objects/listItems')(this)
+    login : require('./login')(clientObj),
+    lists : require('./objects/lists')(clientObj),
+    listItems : require('./objects/listItems')(clientObj)
   };
 };

--- a/package.json
+++ b/package.json
@@ -19,8 +19,13 @@
     "xml2json": "^0.8.2"
   },
   "devDependencies": {
+    "grunt": "~0.4.5",
+    "grunt-concurrent": "^2.3.0",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-fh-build": "~0.0.8",
+    "grunt-node-inspector": "^0.4.1",
+    "grunt-open": "^0.2.3",
+    "grunt-shell": "^1.2.1",
     "mocha": "^2.2.4",
     "nock": "^2.10.0"
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "httpntlm": "^1.5.2",
     "request": "^2.60.0",
     "underscore": "^1.8.3",
-    "underscore-deep-extend": "github:kurtmilam/underscoreDeepExtend",
+    "underscore-deep-extend": "^1.0.4",
     "xml2json": "^0.8.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "xml2json": "^0.8.2"
   },
   "devDependencies": {
+    "grunt": ">=0.4.0",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-fh-build": "~0.0.8",
     "mocha": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "httpntlm": "^1.5.2",
     "request": "^2.60.0",
     "underscore": "^1.8.3",
-    "underscore-deep-extend": "0.0.5",
+    "underscore-deep-extend": "github:kurtmilam/underscoreDeepExtend",
     "xml2json": "^0.8.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "xml2json": "^0.8.2"
   },
   "devDependencies": {
-    "grunt": ">=0.4.0",
+    "grunt": "~0.4.5",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-fh-build": "~0.0.8",
     "mocha": "^2.2.4",

--- a/test/integration/test-list-create-delete.js
+++ b/test/integration/test-list-create-delete.js
@@ -7,16 +7,17 @@ var sharepoint = require('../../sharepoint.js')({
   type: process.env.SP_AUTH_TYPE,
   url: process.env.SP_HOST,
   context : process.env.SP_CONTEXT || 'web',
+  federatedAuthUrl: process.env.SP_FEDERATED_AUTH_URL,
   strictSSL: false
 });
 
 exports.it_should_create_and_delete_lists = function(done) {
   sharepoint.login(function(err) {
-    assert.ok(!err, 'Error logging in: ' + JSON.stringify(err));
+    assert.ifError(err, 'Error logging in: ' + JSON.stringify(err));
     sharepoint.lists.create({
       title: 'mynewlisttester2'
     }, function(err, createRes) {
-      assert.ok(!err, 'Error on creating list: ' + err);
+      assert.ifError(err, 'Error on creating list: ' + err);
       assert.ok(createRes, 'No create result found: ' + createRes);
       idToDelete = createRes.Id;
       return sharepoint.lists.update(createRes.Id, {

--- a/test/integration/test-list-create-delete.js
+++ b/test/integration/test-list-create-delete.js
@@ -27,11 +27,11 @@ exports.it_should_create_and_delete_lists = function(done) {
           console.log('List update error');
           console.log(err);
         }
-        assert.ok(!err, 'Error on updating list: ' + err);
+        assert.ifError(err, 'Error on updating list: ' + err);
         assert.ok(updateResult, 'No update result found: ' + updateResult);
         
         sharepoint.lists.del(idToDelete, function(err) {
-          assert.ok(!err, 'Error on deleting list: ' + err);
+          assert.ifError(err, 'Error on deleting list: ' + err);
           // we've successfully cleaned up - no need to do it later
           idToDelete = false;
           return done();
@@ -48,7 +48,7 @@ exports.after = function(done) {
     return done();
   }
   sharepoint.lists.del(idToDelete, function(err) {
-    assert.ok(!err, 'Error deleting list in cleanup: ' + JSON.stringify(err));
+    assert.ifError(err, 'Error deleting list in cleanup: ' + JSON.stringify(err));
     return done();
   });
 };

--- a/test/integration/test-list-get.js
+++ b/test/integration/test-list-get.js
@@ -13,15 +13,15 @@ exports.it_should_login_and_retrieve_lists = function(done) {
   });
   
   sharepoint.login(function(err) {
-    assert.ok(!err, 'Error logging in' + JSON.stringify(err));
+    assert.ifError(err, 'Error logging in' + JSON.stringify(err));
     sharepoint.lists.list(function(err, listRes) {
-      assert.ok(!err, 'Error listing lists: ' + JSON.stringify(err));
+      assert.ifError(err, 'Error listing lists: ' + JSON.stringify(err));
       var one = _.find(listRes, function(aListItem) {
         return aListItem.ItemCount && aListItem.ItemCount > 0;
       });
       assert.ok(one, 'Error find list result: ' + listRes);
       one.read(function(err, singleListResult) {
-        assert.ok(!err, 'Error reading a list result: ' + JSON.stringify(err));
+        assert.ifError(err, 'Error reading a list result: ' + JSON.stringify(err));
         assert.ok(singleListResult, 'Error finding response from read result: ' + singleListResult);
         return done(null, singleListResult);
       });

--- a/test/integration/test-list-get.js
+++ b/test/integration/test-list-get.js
@@ -8,6 +8,7 @@ exports.it_should_login_and_retrieve_lists = function(done) {
     type: process.env.SP_AUTH_TYPE,
     url: process.env.SP_HOST,
     context : process.env.SP_CONTEXT || 'web',
+    federatedAuthUrl: process.env.SP_FEDERATED_AUTH_URL,
     strictSSL: false
   });
   


### PR DESCRIPTION
Obviously this includes all the changes from my other two pull requests :(

Anyway, hopefully the two commits are relatively self-explanatory. Our MBaaS service uses the sharepointer module to interact with many different sites and users at the same time. We had a couple of problems where the calls to SharePoint were using the wrong user account because (and this is where I'm slightly vague!) there's a singleton object in use which had already authenticated.
