### PR TITLE
remove need for native xml parsing lib 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ node_js:
 sudo: false
 before_install:
   - npm install -g grunt@0.4.5
+  - npm install -g grunt-cli
 install: npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "0.10"
+  - "4.4.2"
 sudo: false
-before_install: npm install -g grunt-cli
+before_install:
+  - npm install -g grunt@0.4.5
 install: npm install

--- a/lib/auth/online/samlResponse.js
+++ b/lib/auth/online/samlResponse.js
@@ -4,28 +4,33 @@
  */
 
 var dotty = require('dotty'),
-parser = require('xml2json');
+xmlJs = require('xml2js'),
+parser =  new xmlJs.Parser({"explicitArray":false}).parseString;
 
 module.exports = function(client, httpOpts, samlResponseBody, waterfallCb){
   if (httpOpts.returnAssertion){
     return cb(null, samlResponseBody);
   }
-  try{
-    samlResponseBody = parser.toJson(samlResponseBody, { object : true });  
-  }catch(err){
-    return waterfallCb('Error parsing XML: ' + err.toString());
-  }
-  var samlError = dotty.get(samlResponseBody, "S:Envelope.S:Body.S:Fault"),
-  token = dotty.get(samlResponseBody, "S:Envelope.S:Body.wst:RequestSecurityTokenResponse.wst:RequestedSecurityToken.wsse:BinarySecurityToken.$t");
-  if (samlError){
-    console.error('Saml error detected on login');
-    console.error(samlError);
-    return waterfallCb('Error logging in - SAML fault detected');
-  }
-  if (!token){
-    console.error('No token in response body:');
-    console.error(samlResponseBody);
-    return waterfallCb('No token found in response body');
-  }
-  return waterfallCb(null, client, httpOpts, token);
+
+  parser(samlResponseBody, function (err,ok){
+    if (err) {
+      waterfallCb('Error parsing XML: ' + err.toString());
+      return;
+    }
+    var samlError = dotty.get(ok, "S:Envelope.S:Body.S:Fault"),
+      token = dotty.get(ok, "S:Envelope.S:Body.wst:RequestSecurityTokenResponse.wst:RequestedSecurityToken.wsse:BinarySecurityToken._");
+    if (samlError){
+      console.error('Saml error detected on login');
+      console.error(samlError);
+      return waterfallCb('Error logging in - SAML fault detected');
+    }
+    if (!token){
+      console.error('No token in response body:');
+      console.error(ok);
+      return waterfallCb('No token found in response body');
+    }
+    return waterfallCb(null, client, httpOpts, token);
+  });
+
+
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharepointer",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Sharepoint library with support for multiple authentication strategies",
   "main": "sharepoint.js",
   "scripts": {
@@ -16,14 +16,14 @@
     "request": "^2.60.0",
     "underscore": "^1.8.3",
     "underscore-deep-extend": "^1.0.4",
-    "xml2json": "^0.8.2"
+    "xml2js": "^0.4.16"
   },
   "devDependencies": {
     "grunt-concurrent": "^2.3.0",
     "grunt-node-inspector": "^0.4.1",
     "grunt-open": "^0.2.3",
     "grunt-shell": "^1.2.1",
-    "grunt" : "~0.4.5",
+    "grunt": "~0.4.5",
     "grunt-contrib-jshint": "0.12.0",
     "grunt-fh-build": "~1.0.1",
     "mocha": "^2.2.4",

--- a/test/fixtures/samlResponse.xml
+++ b/test/fixtures/samlResponse.xml
@@ -1,0 +1,32 @@
+<S:Envelope
+        xmlns:s='http://www.w3.org/2003/05/soap-envelope'
+        xmlns:wsa='http://schemas.xmlsoap.org/ws/2004/08/addressing'
+        xmlns:wst='http://schemas.xmlsoap.org/ws/2005/02/trust'
+        xmlns:wsu='http://schemas.xmlsoap.org/ws/2002/07/utility'
+        xmlns:wsc='http://schemas.microsoft.com/ws/2006/05/context'  xmlns:rm='http://schemas.microsoft.com/2006/11/ResourceManagement' >
+    <S:Header>
+        <wsa:To>
+            http://www.woodgrove.com/sender
+        </wsa:To>
+        <wsa:Action>
+            http://schemas.xmlsoap.org/ws/2005/02/trust/RSTR/Issue
+        </wsa:Action>
+        <wsa:MessageID>
+            uuid:0000010e-0000-0000-C000-000000000048
+        </wsa:MessageID>
+        <wsa:RelatesTo>
+            uuid:00000000-0000-0000-C000-000000000048
+        </wsa:RelatesTo>
+        <wsc:Context>
+            <wsc:InstanceId>19bc8ea5-27f8-4136-97a2-3699697fd271</wsc:InstanceId>
+        </wsc:Context>
+    </S:Header>
+    <S:Body>
+        <wst:RequestSecurityTokenResponse>
+            <wst:RequestedSecurityToken>
+                <wsse:BinarySecurityToken ValueType="wsse:X509v3" EncodingType="wsse:Base64Binary" Id="SecurityToken" >test</wsse:BinarySecurityToken>
+            </wst:RequestedSecurityToken>
+    </wst:RequestSecurityTokenResponse>
+</S:Body>
+</S:Envelope>
+

--- a/test/unit/test-saml-response.js
+++ b/test/unit/test-saml-response.js
@@ -1,0 +1,23 @@
+
+var fs = require('fs');
+var test_file = "./test/fixtures/samlResponse.xml";
+var underTest = require('../../lib/auth/online/samlResponse');
+var assert = require('assert');
+module.exports.test_saml_parse_response_ok  = function (finish){
+  var xml = fs.readFileSync(test_file);
+  underTest({},{},xml,function (err, ok, opts, token){
+    assert.ok(! err, "did not expect an error from saml response");
+    assert.equal("test" ,token, "expected the token to match " + token);
+    finish();
+  });
+};
+
+
+exports.test_saml_parse_response_error  = function (finish){
+  var badXml = "<<>fdfsdfsdf<><<><??><<><>!<>!<!<>!.";
+
+  underTest({},{},badXml,function (err, ok, opts, token){
+     assert.ok(err, "expected an error parsing bad xml");
+    finish();
+  });
+};


### PR DESCRIPTION
xml2json wont build on node4 due to the requirement it has on node-expat. I have changed the lib to be a node 4 and node 0.10 compatible library xmljs. 

I didn't see a  unit test for the saml response, so I have done the best I can to create a valid one. I had to make a minor change to the string being passed to dotty.

@cianclarke Do you know of a sharepoint server I can try this against
