### PR TITLE
fix typo where cb isn't a defined variable

### DIFF
--- a/lib/auth/online/samlResponse.js
+++ b/lib/auth/online/samlResponse.js
@@ -7,14 +7,14 @@ var dotty = require('dotty'),
 xmlJs = require('xml2js'),
 parser =  new xmlJs.Parser({"explicitArray":false}).parseString;
 
-module.exports = function(client, httpOpts, samlResponseBody, waterfallCb){
+module.exports = function(client, httpOpts, samlResponseBody, cb){
   if (httpOpts.returnAssertion){
     return cb(null, samlResponseBody);
   }
 
   parser(samlResponseBody, function (err,ok){
     if (err) {
-      waterfallCb('Error parsing XML: ' + err.toString());
+      cb('Error parsing XML: ' + err.toString());
       return;
     }
     var samlError = dotty.get(ok, "S:Envelope.S:Body.S:Fault"),
@@ -22,14 +22,14 @@ module.exports = function(client, httpOpts, samlResponseBody, waterfallCb){
     if (samlError){
       console.error('Saml error detected on login');
       console.error(samlError);
-      return waterfallCb('Error logging in - SAML fault detected');
+      return cb('Error logging in - SAML fault detected');
     }
     if (!token){
       console.error('No token in response body:');
       console.error(ok);
-      return waterfallCb('No token found in response body');
+      return cb('No token found in response body');
     }
-    return waterfallCb(null, client, httpOpts, token);
+    return cb(null, client, httpOpts, token);
   });
 
 


### PR DESCRIPTION
`cb` was undefined here. Alternatively, I could have renamed it `waterfallCb`. Let me know if you want a test that covers this line, since your current tests didn't have coverage over this error case.
